### PR TITLE
Update meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   # The upstream directions say to use bazel, but this is
   # all bazel ends up doing. Since our bazel package can have
   # glibc version issues on CI, just do things this way.
@@ -30,10 +30,10 @@ requirements:
     # NOTE: tf is currently pulled in from defaults,
     #       so we have flexible channel priority set
     #       in conda-forge.yml
-    # tested and stable against TensorFlow version 2.10 and jax 0.3.17
-    # https://github.com/tensorflow/probability/releases/tag/v0.18.0
-    - tensorflow-base ~=2.10.0
-    - jax ==0.3.17
+    # tested and stable against TensorFlow version 2.11 and jax 0.3.25
+    # https://github.com/tensorflow/probability/releases/tag/v0.19.0
+    - tensorflow-base ~=2.11.0
+    - jax ==0.3.25
     - numpy >=1.13.3
     - absl-py
     - six >=1.10.0


### PR DESCRIPTION
Fixes https://github.com/conda-forge/tensorflow-probability-feedstock/issues/41: somehow a wrong version of the dependencies slipped through.
Pinned TF-base and jax to the correct versions


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


