### PR TITLE
Restore `bazel` build

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,8 +1,19 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
 cdt_name:
 - cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,10 @@ pkgs_dirs:
 
 CONDARC
 
-
-mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
-mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
+mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -12,7 +12,7 @@ function startgroup {
             echo "##[group]$1";;
         travis )
             echo "$1"
-            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:start:'"${1// /}"'\r';;
         github_actions )
             echo "::group::$1";;
         * )
@@ -28,7 +28,7 @@ function endgroup {
         azure )
             echo "##[endgroup]";;
         travis )
-            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:end:'"${1// /}"'\r';;
         github_actions )
             echo "::endgroup::";;
     esac

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ test:
   imports:
     - tensorflow_probability
     - tensorflow_probability.substrates.jax
+    - tensorflow_probability.substrates.numpy
 
 about:
   home: https://www.tensorflow.org/probability/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,18 +13,22 @@ source:
 
 build:
   noarch: python
-  number: 0
-  # The upstream directions say to use bazel, but this is
-  # all bazel ends up doing. Since our bazel package can have
-  # glibc version issues on CI, just do things this way.
+  number: 1
   script:
-    - rm -f BUILD
-    - {{ PYTHON }} -m pip install . --no-deps -vv
-
+    - bazel build :pip_pkg
+    - mkdir tmp-pkg
+    - ./bazel-bin/pip_pkg tmp-pkg
+    - "{{ PYTHON }} -m pip install --upgrade --no-deps -vv tmp-pkg/*.whl"
+    
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - bazel 
   host:
     - python >=3.8
     - pip
+    - absl-py
   run:
     - python >=3.8
     - tensorflow-base >=2.13.0, <2.14.0
@@ -40,6 +44,7 @@ requirements:
 test:
   imports:
     - tensorflow_probability
+    - tensorflow_probability.substrates.jax
 
 about:
   home: https://www.tensorflow.org/probability/


### PR DESCRIPTION
This fixes #49 restoring `bazel` script for building the package. In particular, the files inside `substrates/` were not present in the conda-forge version of `tensorflow-probability`. This caused an issue with the lazy loader, not exposing some classes that [`distrax`](https://github.com/google-deepmind/distrax) uses.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->